### PR TITLE
ENG-1113: Update node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,5 +28,5 @@ outputs:
   description:
     description: 'Description from the changelog entry'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'build/dist/index.js'


### PR DESCRIPTION
https://plainsight-ai.atlassian.net/browse/ENG-1113

# Primary
- Updated spec to use node16 instead of node12 for ubuntu-latest comptibility