### PR TITLE
Run on Node 24 (Node 20 is deprecated)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Use Node.js 18
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 18
           cache: npm

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,10 +15,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Use Node.js 18
+      - name: Use Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/action.yml
+++ b/action.yml
@@ -44,5 +44,5 @@ outputs:
   isProductionRelease:
     description: 'true if version is a production release (e.g. v1.2.3), false otherwise'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'build/dist/index.js'


### PR DESCRIPTION
## What

Switch the action runtime from **Node 20 to Node 24**.

## Why

GitHub deprecated the Node 20 action runtime. This action still declares `using: 'node20'`, so GitHub force-runs it on node24 and emits a deprecation warning on **every** consumer workflow — and this action is invoked by `gh-actions-public/check-release-log`, which runs on essentially every filter release/CI job. So the warning shows up fleet-wide.

## Change

- `action.yml`: `runs.using: 'node20'` → `'node24'`. The committed `build/dist/index.js` bundle is unchanged (it runs on either runtime; no rebuild needed).
- Bump this repo's own CI pins off Node 20: `actions/checkout@v4` → `@v6`, `actions/setup-node@v4` → `@v6`.

This silences the deprecation warning for every downstream filter without any change to parsing behavior.
